### PR TITLE
Fixes TCPTracker memory leak and exposes clean methods in TCPSession

### DIFF
--- a/decode/ethernet_addr.js
+++ b/decode/ethernet_addr.js
@@ -9,6 +9,9 @@ function EthernetAddr(raw_packet, offset) {
 	this.addr[3] = raw_packet[offset + 3];
 	this.addr[4] = raw_packet[offset + 4];
 	this.addr[5] = raw_packet[offset + 5];
+	
+	// The least significant bit of the most significant byte is used to tell if address in unicast or multicast/broadcast
+	this.unicast = !(this.addr[0] & 0x01);  // The bit will be 1 on multicast/broadcast address, and 0 on unicast ones.
 }
 
 EthernetAddr.prototype.toString = function toString() {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     TCPSession: tcp_tracker.TCPSession,
     DNSCache: DNSCache,
     libVersion: binding.lib_version(),
+    findAllDevs: binding.findalldevs,
 
     // Deprecated
     // -------------------------------------------------------------------------

--- a/lib/session.js
+++ b/lib/session.js
@@ -7,6 +7,7 @@ var timers        = require("timers");
 function Session(is_live, device_name, options) {
     var defaultOptions = {
         bufferSize: 10 * 1024 * 1024,  // 10MB
+        snaplen: 65535, // Ready for Jumboframes
         isMonitor: false,
         outfile: "",
         filter: "",
@@ -36,6 +37,13 @@ function Session(is_live, device_name, options) {
         this.options.bufferSize = defaultOptions.bufferSize;
     }
 
+    if (typeof this.options.snaplen === "number" &&
+        !isNaN(this.options.snaplen)) {
+        this.options.snaplen = Math.round(this.options.snaplen);
+    } else {
+        this.options.snaplen = defaultOptions.snaplen;
+    }
+
     // called for each packet read by pcap
     var packet_ready = () => {
         this.on_packet_ready();
@@ -47,6 +55,7 @@ function Session(is_live, device_name, options) {
             this.device_name,
             this.options.filter,
             this.options.bufferSize,
+            this.options.snaplen,
             this.options.outfile,
             packet_ready,
             this.options.isMonitor,
@@ -56,6 +65,7 @@ function Session(is_live, device_name, options) {
             this.device_name,
             this.options.filter,
             this.options.bufferSize,
+            this.options.snaplen,
             this.options.outfile,
             packet_ready,
             this.options.isMonitor,
@@ -64,7 +74,7 @@ function Session(is_live, device_name, options) {
 
     this.fd = this.session.fileno();
     this.opened = true;
-    this.buf = new Buffer(this.options.bufferSize || 65535);
+    this.buf = new Buffer(this.options.snaplen);
     this.header = new Buffer(16);
 
     if (is_live) {

--- a/lib/tcpTracker.js
+++ b/lib/tcpTracker.js
@@ -92,6 +92,18 @@ function TCPSession() {
 }
 inherits(TCPSession, EventEmitter);
 
+TCPSession.prototype.clean_send = function() {
+    this.send_packets = {};
+    this.send_acks = {};
+    this.send_retrans = {};
+}
+
+TCPSession.prototype.clean_recv = function() {
+    this.recv_packets = {};
+    this.recv_acks = {};
+    this.recv_retrans = {};
+}
+
 TCPSession.prototype.track = function (packet) {
     var ip  = packet.payload.payload;
     var tcp = ip.payload;

--- a/lib/tcpTracker.js
+++ b/lib/tcpTracker.js
@@ -9,6 +9,10 @@ function TCPTracker() {
 }
 inherits(TCPTracker, EventEmitter);
 
+TCPTracker.prototype.clean_session = function(key) {
+    delete this.sessions[key];
+}
+
 TCPTracker.prototype.track_packet = function (packet) {
     var ip, tcp, src, dst, key, session;
 
@@ -30,6 +34,11 @@ TCPTracker.prototype.track_packet = function (packet) {
             is_new = true;
             session = new TCPSession();
             this.sessions[key] = session;
+            // Remove session when finishes
+            var that = this;
+            session.on('end', function () {
+                that.clean_session(key); 
+            });
         }
 
         session.track(packet);

--- a/src/pcap_session.cc
+++ b/src/pcap_session.cc
@@ -129,7 +129,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
     Nan::HandleScope scope;
     char errbuf[PCAP_ERRBUF_SIZE];
 
-    if (info.Length() == 7) {
+    if (info.Length() == 8) {
         if (!info[0]->IsString()) {
             Nan::ThrowTypeError("pcap Open: info[0] must be a String");
             return;
@@ -142,35 +142,40 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
             Nan::ThrowTypeError("pcap Open: info[2] must be a Number");
             return;
         }
-        if (!info[3]->IsString()) {
-            Nan::ThrowTypeError("pcap Open: info[3] must be a String");
+        if (!info[3]->IsInt32()) {
+            Nan::ThrowTypeError("pcap Open: info[3] must be a Number");
             return;
         }
-        if (!info[4]->IsFunction()) {
-            Nan::ThrowTypeError("pcap Open: info[4] must be a Function");
+        if (!info[4]->IsString()) {
+            Nan::ThrowTypeError("pcap Open: info[4] must be a String");
             return;
         }
-        if (!info[5]->IsBoolean()) {
-            Nan::ThrowTypeError("pcap Open: info[5] must be a Boolean");
+        if (!info[5]->IsFunction()) {
+            Nan::ThrowTypeError("pcap Open: info[5] must be a Function");
             return;
         }
-        if (!info[6]->IsInt32()) {
-            Nan::ThrowTypeError("pcap Open: info[6] must be a Number");
+        if (!info[6]->IsBoolean()) {
+            Nan::ThrowTypeError("pcap Open: info[6] must be a Boolean");
+            return;
+        }
+        if (!info[7]->IsInt32()) {
+            Nan::ThrowTypeError("pcap Open: info[7] must be a Number");
             return;
         }
     } else {
-        Nan::ThrowTypeError("pcap Open: expecting 7 arguments");
+        Nan::ThrowTypeError("pcap Open: expecting 8 arguments");
         return;
     }
     Nan::Utf8String device(info[0]->ToString());
     Nan::Utf8String filter(info[1]->ToString());
     int buffer_size = info[2]->Int32Value();
-    int timeout = info[6]->Int32Value();
-    Nan::Utf8String pcap_output_filename(info[3]->ToString());
+    int snaplen = info[3]->Int32Value();
+    int timeout = info[7]->Int32Value();
+    Nan::Utf8String pcap_output_filename(info[4]->ToString());
 
     PcapSession* session = Nan::ObjectWrap::Unwrap<PcapSession>(info.This());
 
-    session->packet_ready_cb.Reset(info[4].As<Function>());
+    session->packet_ready_cb.Reset(info[5].As<Function>());
     session->pcap_dump_handle = NULL;
 
     if (live) {
@@ -187,7 +192,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
         }
 
         // 64KB is the max IPv4 packet size
-        if (pcap_set_snaplen(session->pcap_handle, 65535) != 0) {
+        if (pcap_set_snaplen(session->pcap_handle, snaplen) != 0) {
             Nan::ThrowError("error setting snaplen");
             return;
         }
@@ -212,7 +217,7 @@ void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
 
         // fixes a previous to-do that was here.
         if (info.Length() == 6) {
-            if (info[5]->Int32Value()) {
+            if (info[6]->Int32Value()) {
                 if (pcap_set_rfmon(session->pcap_handle, 1) != 0) {
                     Nan::ThrowError(pcap_geterr(session->pcap_handle));
                     return;


### PR DESCRIPTION
Both changes are related to memory leaks.

Fist one solves that TCPTracker do not clean TCPSessions after they finish.

Second one offers methods to clean recv and/or send packets in TCPSessions to allow long running TCP sniffing over one single session (example long file download or video streamming). You should call this methods from your TCP Processor (in my case an HTTP interpeter). Keep in mind that calling this methods will impact on TCPSession stats calculator.